### PR TITLE
Handle Color3 type

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -2,13 +2,7 @@
 
 use rbx_dom_weak::{RbxValue, RbxValueType};
 use rlua::{
-    Context,
-    MetaMethod,
-    Result as LuaResult,
-    ToLua,
-    UserData,
-    UserDataMethods,
-    Value as LuaValue
+    Context, MetaMethod, Result as LuaResult, ToLua, UserData, UserDataMethods, Value as LuaValue
 };
 
 pub fn rbxvalue_to_lua<'lua>(
@@ -154,9 +148,7 @@ struct Color3Value {
 
 impl Color3Value {
     pub fn new(value: [f32; 3]) -> Self {
-        Self {
-            value,
-        }
+        Self { value }
     }
 
     fn meta_to_string<'lua>(&self, context: Context<'lua>) -> rlua::Result<rlua::Value<'lua>> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -99,7 +99,7 @@ pub fn lua_to_rbxvalue(ty: RbxValueType, value: LuaValue<'_>) -> LuaResult<RbxVa
             value: value as i64,
         }),
 
-        (RbxValueType::Color3, LuaValue::UserData(user_data))
+        (RbxValueType::Color3, LuaValue::UserData(ref user_data))
             if user_data.is::<Color3Value>() =>
         {
             let color = &*user_data.borrow::<Color3Value>().unwrap();

--- a/src/value.rs
+++ b/src/value.rs
@@ -160,6 +160,22 @@ impl Color3Value {
     pub fn new(value: [f32; 3]) -> Self {
         Self { value }
     }
+
+    fn meta_index<'lua>(
+        &self,
+        context: Context<'lua>,
+        key: &str,
+    ) -> rlua::Result<rlua::Value<'lua>> {
+        match key {
+            "r" => self.value[0].to_lua(context),
+            "g" => self.value[1].to_lua(context),
+            "b" => self.value[2].to_lua(context),
+            _ => Err(rlua::Error::external(format!(
+                "'{}' is not a valid member of Color3",
+                key
+            ))),
+        }
+    }
 }
 
 impl From<&Color3Value> for RbxValue {
@@ -172,6 +188,10 @@ impl UserData for Color3Value {
     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
         methods.add_meta_method(MetaMethod::ToString, |context, this, _arg: ()| {
             this.to_string().to_lua(context)
+        });
+
+        methods.add_meta_method(MetaMethod::Index, |context, this, key: String| {
+            this.meta_index(context, &key)
         });
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,7 +2,7 @@
 
 use rbx_dom_weak::{RbxValue, RbxValueType};
 use rlua::{
-    Context, MetaMethod, Result as LuaResult, ToLua, UserData, UserDataMethods, Value as LuaValue
+    Context, MetaMethod, Result as LuaResult, ToLua, UserData, UserDataMethods, Value as LuaValue,
 };
 
 pub fn rbxvalue_to_lua<'lua>(

--- a/test-models/color3value.rbxmx
+++ b/test-models/color3value.rbxmx
@@ -1,0 +1,17 @@
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+	<Meta name="ExplicitAutoJoints">true</Meta>
+	<External>null</External>
+	<External>nil</External>
+	<Item class="Color3Value" referent="RBX852DF1A55D634EF992DDA3BC11851AF6">
+		<Properties>
+			<BinaryString name="AttributesSerialize"></BinaryString>
+			<string name="Name">Color3Value</string>
+			<BinaryString name="Tags"></BinaryString>
+			<Color3 name="Value">
+				<R>1</R>
+				<G>0.729411781</G>
+				<B>0.254901975</B>
+			</Color3>
+		</Properties>
+	</Item>
+</roblox>

--- a/test-scripts/type-color3.lua
+++ b/test-scripts/type-color3.lua
@@ -1,0 +1,12 @@
+local value = remodel.readModelFile("test-models/color3value.rbxmx")[1]
+
+local color3 = remodel.getRawProperty(value, "Value")
+
+local function round(number)
+    local integral, fraction = math.modf(number)
+    return integral + (fraction > 0.5 and 1 or 0)
+end
+
+assert(round(color3.r * 255) == 255)
+assert(round(color3.g * 255) == 186)
+assert(round(color3.b * 255) == 65)


### PR DESCRIPTION
I just started to use remodel for a project and I find it pretty useful! 

I'm currently using it to build a model from a set of place files: the goal is to have a separate place for each world, and then read each of them with remodel and extract the necessary data.

I ended up reading the current Lighting properties of each place and creating a series of Value objects to include into the final model. So in order to serialize the Ambient property, for example, I needed that Color3 value.

I know there was not any issues related to that so I don't know if you had something else in mind, just let me know.