### PR TITLE
Add CFrame type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 
+* Added support for CFrame ([#48](https://github.com/rojo-rbx/remodel/pull/48))
 * Added support for Vector3, and improved Vector3int16 ([#46](https://github.com/rojo-rbx/remodel/pull/46))
 * Added Color3.fromRGB(red, blue, green) ([#44](https://github.com/rojo-rbx/remodel/pull/44))
 

--- a/src/roblox_api/cframe.rs
+++ b/src/roblox_api/cframe.rs
@@ -20,25 +20,11 @@ impl CFrame {
     }
 }
 
-#[derive(Debug, Clone)]
-enum Either {
-    Number(f32),
-    Vector(Vector3Value),
-    Other,
-}
-
-impl From<LuaValue<'_>> for Either {
-    fn from(value: LuaValue<'_>) -> Self {
-        match value {
-            LuaValue::Number(number) => Self::Number(number as f32),
-            LuaValue::Integer(number) => Self::Number(number as f32),
-            LuaValue::UserData(user_data) => user_data
-                .borrow::<Vector3Value>()
-                .ok()
-                .map(|vector| Self::Vector(*vector))
-                .unwrap_or(Self::Other),
-            _ => Either::Other,
-        }
+fn try_into_f32(value: LuaValue<'_>) -> Option<f32> {
+    match value {
+        LuaValue::Number(num) => Some(num as f32),
+        LuaValue::Integer(int) => Some(int as f32),
+        _ => None,
     }
 }
 
@@ -52,24 +38,11 @@ impl UserData for CFrame {
                 Option<LuaValue<'_>>,
                 Option<LuaValue<'_>>,
             )| {
-                let arguments = (
-                    arguments.0.map(Either::from),
-                    arguments.1.map(Either::from),
-                    arguments.2.map(Either::from),
-                );
                 match arguments {
-                    (None, None, None) => Ok(Self::from_position(0.0, 0.0, 0.0)),
-                    (Some(Either::Number(x)), None, None) => {
-                        Ok(Self::from_position(x as f32, 0.0, 0.0))
-                    }
-                    (Some(Either::Number(x)), Some(Either::Number(y)), None) => {
-                        Ok(Self::from_position(x as f32, y as f32, 0.0))
-                    }
-                    (Some(Either::Number(x)), Some(Either::Number(y)), Some(Either::Number(z))) => {
-                        Ok(Self::from_position(x as f32, y as f32, z as f32))
-                    }
-                    (Some(Either::Vector(position)), None, None) => {
-                        Ok(CFrameValue::new(DomCFrame::new(
+                    (None, None, None) => return Ok(Self::from_position(0.0, 0.0, 0.0)),
+                    (Some(LuaValue::UserData(user_data)), None, None) => {
+                        let position = &*user_data.borrow::<Vector3Value>()?;
+                        return Ok(CFrameValue::new(DomCFrame::new(
                             position.inner(),
                             // TODO: replace with `rbx_dom_weak::types::Matrix3::identity()` once
                             // a version higher than 0.3.0 of rbx_types ships
@@ -78,8 +51,17 @@ impl UserData for CFrame {
                                 Vector3::new(0.0, 1.0, 0.0),
                                 Vector3::new(0.0, 0.0, 1.0),
                             ),
-                        )))
+                        )));
                     }
+                    _ => {}
+                };
+
+                let x = arguments.0.and_then(try_into_f32);
+                let y = arguments.1.and_then(try_into_f32);
+                let z = arguments.2.and_then(try_into_f32);
+
+                match (x, y, z) {
+                    (Some(x), Some(y), Some(z)) => Ok(Self::from_position(x, y, z)),
                     _ => Err(rlua::Error::external(
                         "invalid argument #1 to 'new' (Vector3 expected)",
                     )),

--- a/src/roblox_api/cframe.rs
+++ b/src/roblox_api/cframe.rs
@@ -1,13 +1,13 @@
-use rbx_dom_weak::types::{CFrame as DomCFrame, Matrix3, Vector3};
+use rbx_dom_weak::types::{CFrame, Matrix3, Vector3};
 use rlua::{UserData, UserDataMethods, Value as LuaValue};
 
 use crate::value::{CFrameValue, Vector3Value};
 
-pub struct CFrame;
+pub struct CFrameUserData;
 
-impl CFrame {
+impl CFrameUserData {
     fn from_position(x: f32, y: f32, z: f32) -> CFrameValue {
-        CFrameValue::new(DomCFrame::new(
+        CFrameValue::new(CFrame::new(
             Vector3::new(x as f32, y as f32, z as f32),
             // TODO: replace with `Matrix3::identity()` once
             // a version higher than 0.3.0 of rbx_types ships
@@ -28,7 +28,7 @@ fn try_into_f32(value: LuaValue<'_>) -> Option<f32> {
     }
 }
 
-impl UserData for CFrame {
+impl UserData for CFrameUserData {
     fn add_methods<'lua, T: UserDataMethods<'lua, Self>>(methods: &mut T) {
         methods.add_function(
             "new",
@@ -42,7 +42,7 @@ impl UserData for CFrame {
                     (None, None, None) => return Ok(Self::from_position(0.0, 0.0, 0.0)),
                     (Some(LuaValue::UserData(user_data)), None, None) => {
                         let position = &*user_data.borrow::<Vector3Value>()?;
-                        return Ok(CFrameValue::new(DomCFrame::new(
+                        return Ok(CFrameValue::new(CFrame::new(
                             position.inner(),
                             // TODO: replace with `rbx_dom_weak::types::Matrix3::identity()` once
                             // a version higher than 0.3.0 of rbx_types ships

--- a/src/roblox_api/cframe.rs
+++ b/src/roblox_api/cframe.rs
@@ -1,0 +1,112 @@
+use rlua::{UserData, UserDataMethods, Value as LuaValue};
+
+use crate::value::{CFrameValue, Vector3Value};
+
+pub struct CFrame;
+
+impl CFrame {
+    fn from_position(x: f32, y: f32, z: f32) -> CFrameValue {
+        CFrameValue::new(rbx_dom_weak::types::CFrame::new(
+            rbx_dom_weak::types::Vector3::new(x as f32, y as f32, z as f32),
+            // TODO: replace with `rbx_dom_weak::types::Matrix3::identity()` once
+            // a version higher than 0.3.0 of rbx_types ships
+            rbx_dom_weak::types::Matrix3::new(
+                rbx_dom_weak::types::Vector3::new(1.0, 0.0, 0.0),
+                rbx_dom_weak::types::Vector3::new(0.0, 1.0, 0.0),
+                rbx_dom_weak::types::Vector3::new(0.0, 0.0, 1.0),
+            ),
+        ))
+    }
+}
+
+impl UserData for CFrame {
+    fn add_methods<'lua, T: UserDataMethods<'lua, Self>>(methods: &mut T) {
+        methods.add_function(
+            "new",
+            |_context,
+             triplet: (
+                Option<LuaValue<'_>>,
+                Option<LuaValue<'_>>,
+                Option<LuaValue<'_>>,
+            )| {
+                match triplet {
+                    (None, None, None) => Ok(Self::from_position(0.0, 0.0, 0.0)),
+                    (Some(LuaValue::Number(x)), None, None) => {
+                        Ok(Self::from_position(x as f32, 0.0, 0.0))
+                    }
+                    (Some(LuaValue::Integer(x)), None, None) => {
+                        Ok(Self::from_position(x as f32, 0.0, 0.0))
+                    }
+                    (Some(LuaValue::Number(x)), Some(LuaValue::Number(y)), None) => {
+                        Ok(Self::from_position(x as f32, y as f32, 0.0))
+                    }
+                    (Some(LuaValue::Number(x)), Some(LuaValue::Integer(y)), None) => {
+                        Ok(Self::from_position(x as f32, y as f32, 0.0))
+                    }
+                    (Some(LuaValue::Integer(x)), Some(LuaValue::Integer(y)), None) => {
+                        Ok(Self::from_position(x as f32, y as f32, 0.0))
+                    }
+                    (Some(LuaValue::Integer(x)), Some(LuaValue::Number(y)), None) => {
+                        Ok(Self::from_position(x as f32, y as f32, 0.0))
+                    }
+                    (
+                        Some(LuaValue::Number(x)),
+                        Some(LuaValue::Number(y)),
+                        Some(LuaValue::Number(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Number(x)),
+                        Some(LuaValue::Integer(y)),
+                        Some(LuaValue::Number(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Number(x)),
+                        Some(LuaValue::Number(y)),
+                        Some(LuaValue::Integer(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Number(x)),
+                        Some(LuaValue::Integer(y)),
+                        Some(LuaValue::Integer(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Integer(x)),
+                        Some(LuaValue::Integer(y)),
+                        Some(LuaValue::Integer(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Integer(x)),
+                        Some(LuaValue::Number(y)),
+                        Some(LuaValue::Integer(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Integer(x)),
+                        Some(LuaValue::Integer(y)),
+                        Some(LuaValue::Number(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (
+                        Some(LuaValue::Integer(x)),
+                        Some(LuaValue::Number(y)),
+                        Some(LuaValue::Number(z)),
+                    ) => Ok(Self::from_position(x as f32, y as f32, z as f32)),
+                    (Some(LuaValue::UserData(user_data)), None, None) => {
+                        let position = &*user_data.borrow::<Vector3Value>()?;
+                        Ok(CFrameValue::new(rbx_dom_weak::types::CFrame::new(
+                            (*position).into(),
+                            // TODO: replace with `rbx_dom_weak::types::Matrix3::identity()` once
+                            // a version higher than 0.3.0 of rbx_types ships
+                            rbx_dom_weak::types::Matrix3::new(
+                                rbx_dom_weak::types::Vector3::new(1.0, 0.0, 0.0),
+                                rbx_dom_weak::types::Vector3::new(0.0, 1.0, 0.0),
+                                rbx_dom_weak::types::Vector3::new(0.0, 0.0, 1.0),
+                            ),
+                        )))
+                    }
+                    _ => Err(rlua::Error::external(
+                        "invalid argument #1 to 'new' (Vector3 expected)",
+                    )),
+                }
+            },
+        );
+    }
+}

--- a/src/roblox_api/cframe.rs
+++ b/src/roblox_api/cframe.rs
@@ -1,3 +1,4 @@
+use rbx_dom_weak::types::{CFrame as DomCFrame, Matrix3, Vector3};
 use rlua::{UserData, UserDataMethods, Value as LuaValue};
 
 use crate::value::{CFrameValue, Vector3Value};
@@ -6,14 +7,14 @@ pub struct CFrame;
 
 impl CFrame {
     fn from_position(x: f32, y: f32, z: f32) -> CFrameValue {
-        CFrameValue::new(rbx_dom_weak::types::CFrame::new(
-            rbx_dom_weak::types::Vector3::new(x as f32, y as f32, z as f32),
-            // TODO: replace with `rbx_dom_weak::types::Matrix3::identity()` once
+        CFrameValue::new(DomCFrame::new(
+            Vector3::new(x as f32, y as f32, z as f32),
+            // TODO: replace with `Matrix3::identity()` once
             // a version higher than 0.3.0 of rbx_types ships
-            rbx_dom_weak::types::Matrix3::new(
-                rbx_dom_weak::types::Vector3::new(1.0, 0.0, 0.0),
-                rbx_dom_weak::types::Vector3::new(0.0, 1.0, 0.0),
-                rbx_dom_weak::types::Vector3::new(0.0, 0.0, 1.0),
+            Matrix3::new(
+                Vector3::new(1.0, 0.0, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+                Vector3::new(0.0, 0.0, 1.0),
             ),
         ))
     }
@@ -68,14 +69,14 @@ impl UserData for CFrame {
                         Ok(Self::from_position(x as f32, y as f32, z as f32))
                     }
                     (Some(Either::Vector(position)), None, None) => {
-                        Ok(CFrameValue::new(rbx_dom_weak::types::CFrame::new(
-                            position.into(),
+                        Ok(CFrameValue::new(DomCFrame::new(
+                            position.inner(),
                             // TODO: replace with `rbx_dom_weak::types::Matrix3::identity()` once
                             // a version higher than 0.3.0 of rbx_types ships
-                            rbx_dom_weak::types::Matrix3::new(
-                                rbx_dom_weak::types::Vector3::new(1.0, 0.0, 0.0),
-                                rbx_dom_weak::types::Vector3::new(0.0, 1.0, 0.0),
-                                rbx_dom_weak::types::Vector3::new(0.0, 0.0, 1.0),
+                            Matrix3::new(
+                                Vector3::new(1.0, 0.0, 0.0),
+                                Vector3::new(0.0, 1.0, 0.0),
+                                Vector3::new(0.0, 0.0, 1.0),
                             ),
                         )))
                     }

--- a/src/roblox_api/mod.rs
+++ b/src/roblox_api/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     value::{Color3Value, Vector3Value, Vector3int16Value},
 };
 
-use cframe::CFrame;
+use cframe::CFrameUserData;
 pub use instance::LuaInstance;
 
 pub struct RobloxApi;
@@ -22,7 +22,7 @@ impl RobloxApi {
         context.globals().set("Vector3", Vector3)?;
         context.globals().set("Vector3int16", Vector3int16)?;
         context.globals().set("Color3", Color3)?;
-        context.globals().set("CFrame", CFrame)?;
+        context.globals().set("CFrame", CFrameUserData)?;
 
         Ok(())
     }

--- a/src/roblox_api/mod.rs
+++ b/src/roblox_api/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     value::{Color3Value, Vector3Value, Vector3int16Value},
 };
 
-use cframe::*;
+use cframe::CFrame;
 pub use instance::LuaInstance;
 
 pub struct RobloxApi;

--- a/src/roblox_api/mod.rs
+++ b/src/roblox_api/mod.rs
@@ -1,3 +1,4 @@
+mod cframe;
 mod instance;
 
 use std::sync::Arc;
@@ -10,6 +11,7 @@ use crate::{
     value::{Color3Value, Vector3Value, Vector3int16Value},
 };
 
+use cframe::*;
 pub use instance::LuaInstance;
 
 pub struct RobloxApi;
@@ -20,6 +22,7 @@ impl RobloxApi {
         context.globals().set("Vector3", Vector3)?;
         context.globals().set("Vector3int16", Vector3int16)?;
         context.globals().set("Color3", Color3)?;
+        context.globals().set("CFrame", CFrame)?;
 
         Ok(())
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -225,12 +225,6 @@ impl UserData for Color3uint8Value {
 #[derive(Debug, Clone, Copy)]
 pub struct Vector3Value(Vector3);
 
-impl Into<Vector3> for Vector3Value {
-    fn into(self) -> Vector3 {
-        self.0
-    }
-}
-
 impl fmt::Display for Vector3Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}, {}, {}", self.0.x, self.0.y, self.0.z)
@@ -240,6 +234,10 @@ impl fmt::Display for Vector3Value {
 impl Vector3Value {
     pub fn new(value: Vector3) -> Self {
         Self(value)
+    }
+
+    pub fn inner(&self) -> Vector3 {
+        self.0
     }
 
     fn meta_index<'lua>(

--- a/src/value.rs
+++ b/src/value.rs
@@ -427,7 +427,7 @@ impl CFrameValue {
             "YVector" => Vector3Value::new(self.0.orientation.y).to_lua(context),
             "ZVector" => Vector3Value::new(self.0.orientation.z).to_lua(context),
             _ => Err(rlua::Error::external(format!(
-                "'{}' is not a valid member of Vector3",
+                "'{}' is not a valid member of CFrame",
                 key
             ))),
         }

--- a/test-scripts/type-cframe.lua
+++ b/test-scripts/type-cframe.lua
@@ -12,18 +12,13 @@ end
 
 -- new with combinations of integer and floats
 assertCFramePosition(CFrame.new(), 0, 0, 0)
-assertCFramePosition(CFrame.new(1), 1, 0, 0)
-assertCFramePosition(CFrame.new(1, 2), 1, 2, 0)
 assertCFramePosition(CFrame.new(1, 2, 3), 1, 2, 3)
-
-assertCFramePosition(CFrame.new(1.5), 1.5, 0, 0)
-assertCFramePosition(CFrame.new(1.5, 2), 1.5, 2, 0)
 assertCFramePosition(CFrame.new(1.5, 2, 3), 1.5, 2, 3)
-
-assertCFramePosition(CFrame.new(1, 2.5), 1, 2.5, 0)
 assertCFramePosition(CFrame.new(1, 2.5, 3), 1, 2.5, 3)
-
 assertCFramePosition(CFrame.new(1, 2, 3.5), 1, 2, 3.5)
+assertCFramePosition(CFrame.new(1.5, 2.5, 3), 1.5, 2.5, 3)
+assertCFramePosition(CFrame.new(1, 2.5, 3.5), 1, 2.5, 3.5)
+assertCFramePosition(CFrame.new(1.5, 2.5, 3.5), 1.5, 2.5, 3.5)
 
 -- new from Vector3
 assertCFramePosition(CFrame.new(Vector3.new(1, 2, 3)), 1, 2, 3)

--- a/test-scripts/type-cframe.lua
+++ b/test-scripts/type-cframe.lua
@@ -1,0 +1,40 @@
+local function assertCFramePosition(vec, x, y, z)
+    assert(vec.X == x, ("%f ~= %f"):format(vec.X, x))
+    assert(vec.Y == y, ("%f ~= %f"):format(vec.Y, y))
+    assert(vec.Z == z, ("%f ~= %f"):format(vec.Z, z))
+end
+
+local function assertVector(vec, x, y, z)
+    assert(vec.X == x, ("x: %f ~= %f (%s)"):format(vec.X, x, tostring(vec)))
+    assert(vec.Y == y, ("y: %f ~= %f (%s)"):format(vec.Y, y, tostring(vec)))
+    assert(vec.Z == z, ("z: %f ~= %f (%s)"):format(vec.Z, z, tostring(vec)))
+end
+
+-- new with combinations of integer and floats
+assertCFramePosition(CFrame.new(), 0, 0, 0)
+assertCFramePosition(CFrame.new(1), 1, 0, 0)
+assertCFramePosition(CFrame.new(1, 2), 1, 2, 0)
+assertCFramePosition(CFrame.new(1, 2, 3), 1, 2, 3)
+
+assertCFramePosition(CFrame.new(1.5), 1.5, 0, 0)
+assertCFramePosition(CFrame.new(1.5, 2), 1.5, 2, 0)
+assertCFramePosition(CFrame.new(1.5, 2, 3), 1.5, 2, 3)
+
+assertCFramePosition(CFrame.new(1, 2.5), 1, 2.5, 0)
+assertCFramePosition(CFrame.new(1, 2.5, 3), 1, 2.5, 3)
+
+assertCFramePosition(CFrame.new(1, 2, 3.5), 1, 2, 3.5)
+
+-- new from Vector3
+assertCFramePosition(CFrame.new(Vector3.new(1, 2, 3)), 1, 2, 3)
+
+-- properties
+assertVector(CFrame.new().XVector, 1, 0, 0)
+assertVector(CFrame.new().YVector, 0, 1, 0)
+assertVector(CFrame.new().ZVector, 0, 0, 1)
+
+assertVector(CFrame.new().RightVector, 1, 0, 0)
+assertVector(CFrame.new().UpVector, 0, 1, 0)
+assertVector(CFrame.new().LookVector, -0, -0, -1)
+
+assert(tostring(CFrame.new(7, 8, 9)) == "7, 8, 9, 1, 0, 0, 0, 1, 0, 0, 0, 1", "got " .. tostring(CFrame.new()))


### PR DESCRIPTION
This adds the `CFrame.new` constructor. The pattern matching is a bit scary, but I wanted to make sure to cover at least:

* `CFrame.new(x, y, z)` with all combinations of integer and float
* `CFrame.new(position)`

Related to #15 