### PR TITLE
Update reqwest to a ClientBuilder, and extend the timeout to 3 minutes

### DIFF
--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -1,3 +1,10 @@
+use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
+use reqwest::{
+    header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
+    StatusCode,
+};
+use rlua::{Context, UserData, UserDataMethods};
+use std::time::Duration;
 use std::{
     ffi::OsStr,
     fs::{self, File},
@@ -5,13 +12,6 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use std::time::Duration;
-use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
-use reqwest::{
-    header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
-    StatusCode,
-};
-use rlua::{Context, UserData, UserDataMethods};
 
 use crate::{
     remodel_context::RemodelContext,
@@ -198,7 +198,8 @@ impl Remodel {
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60 * 3))
-            .build().map_err(rlua::Error::external)?;
+            .build()
+            .map_err(rlua::Error::external)?;
 
         let mut request = client.get(&url);
 
@@ -246,7 +247,8 @@ impl Remodel {
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60 * 3))
-            .build().map_err(rlua::Error::external)?;
+            .build()
+            .map_err(rlua::Error::external)?;
         let mut request = client.get(&url);
 
         if let Some(auth_cookie) = auth_cookie {
@@ -347,7 +349,8 @@ impl Remodel {
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60 * 3))
-            .build().map_err(rlua::Error::external)?;
+            .build()
+            .map_err(rlua::Error::external)?;
 
         let build_request = move || {
             client

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -4,7 +4,7 @@ use std::{
     io::{BufReader, BufWriter, Read},
     path::Path,
     sync::Arc,
-    time::Duration
+    time::Duration,
 };
 
 use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
@@ -13,7 +13,6 @@ use reqwest::{
     StatusCode,
 };
 use rlua::{Context, UserData, UserDataMethods};
-
 
 use crate::{
     remodel_context::RemodelContext,

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -5,7 +5,7 @@ use std::{
     path::Path,
     sync::Arc,
 };
-
+use std::time::Duration;
 use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
 use reqwest::{
     header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
@@ -196,7 +196,10 @@ impl Remodel {
         let auth_cookie = re_context.auth_cookie();
         let url = format!("https://assetdelivery.roblox.com/v1/asset/?id={}", asset_id);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60 * 3))
+            .build().map_err(rlua::Error::external)?;
+
         let mut request = client.get(&url);
 
         if let Some(auth_cookie) = auth_cookie {
@@ -241,7 +244,9 @@ impl Remodel {
         let auth_cookie = re_context.auth_cookie();
         let url = format!("https://assetdelivery.roblox.com/v1/asset/?id={}", asset_id);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60 * 3))
+            .build().map_err(rlua::Error::external)?;
         let mut request = client.get(&url);
 
         if let Some(auth_cookie) = auth_cookie {
@@ -340,7 +345,10 @@ impl Remodel {
             asset_id
         );
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60 * 3))
+            .build().map_err(rlua::Error::external)?;
+
         let build_request = move || {
             client
                 .post(&url)

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -1,10 +1,10 @@
-use std::time::Duration;
 use std::{
     ffi::OsStr,
     fs::{self, File},
     io::{BufReader, BufWriter, Read},
     path::Path,
     sync::Arc,
+    time::Duration
 };
 
 use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -1,9 +1,3 @@
-use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
-use reqwest::{
-    header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
-    StatusCode,
-};
-use rlua::{Context, UserData, UserDataMethods};
 use std::time::Duration;
 use std::{
     ffi::OsStr,
@@ -12,6 +6,14 @@ use std::{
     path::Path,
     sync::Arc,
 };
+
+use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
+use reqwest::{
+    header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
+    StatusCode,
+};
+use rlua::{Context, UserData, UserDataMethods};
+
 
 use crate::{
     remodel_context::RemodelContext,


### PR DESCRIPTION
**Problem**
When uploading or downloading big assets, remodel defaults to the `reqwest` library default timeout, which is only **30 seconds**
(according to [reqwest/src/blocking/client.rs#L349](https://github.com/seanmonstar/reqwest/blob/66c1b48167c428ec2aadf03fdea71a7b5f089750/src/blocking/client.rs#L349))

**Solution**
Increase the timeout to *three minutes*. This is an arbitrary number but it seems sensible. 
