### PR TITLE
Switch from rlua to mlua

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.51.0"]
+        rust_version: [stable, "1.53.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.46.0"]
+        rust_version: [stable, "1.51.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lua-src"
+version = "544.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708ba3c844d5e9d38def4a09dd871c17c370f519b3c4b7261fbabe4a613a814c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.3.4+resty073ac54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640b09e99575a442b4da0ef406a78188a1a4313bb9ead7b5b20ec12cc480130f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "lz4"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +811,22 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "mlua"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e2194305aa8301d5da9c1c98640047f4219f6b95c190f6860338ab9872b686"
+dependencies = [
+ "bstr",
+ "cc",
+ "lua-src",
+ "luajit-src",
+ "num-traits",
+ "once_cell",
+ "pkg-config",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1288,13 +1322,13 @@ dependencies = [
  "base64 0.13.0",
  "env_logger",
  "log",
+ "mlua",
  "rbx_binary",
  "rbx_dom_weak",
  "rbx_reflection",
  "rbx_reflection_database",
  "rbx_xml",
  "reqwest",
- "rlua",
  "serde",
  "serde_json",
  "structopt",
@@ -1345,19 +1379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlua"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93397b9792dc237cab7554ab4c4128b8aa5fc9ec25892cfd82c92286055313d0"
-dependencies = [
- "bitflags",
- "bstr",
- "cc",
- "libc",
- "num-traits",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1404,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,13 @@ backtrace = "0.3.61"
 base64 = "0.13.0"
 log = "0.4.14"
 reqwest = "0.9.24"
-rlua = "0.17.1"
 serde = "1.0.130"
 serde_json = "1.0.68"
 structopt = "0.3.23"
+
+[dependencies.mlua]
+version = "0.7.4"
+features = ["lua53", "vendored"]
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.2"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ remodel = { source = "rojo-rbx/remodel", version = "0.9.1" }
 You can download pre-built binaries from [Remodel's GitHub Releases page](https://github.com/rojo-rbx/remodel/releases).
 
 ### From crates.io
-You'll need Rust 1.46.0 or newer.
+You'll need Rust 1.51.0 or newer.
 
 ```bash
 cargo install remodel

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ remodel = { source = "rojo-rbx/remodel", version = "0.9.1" }
 You can download pre-built binaries from [Remodel's GitHub Releases page](https://github.com/rojo-rbx/remodel/releases).
 
 ### From crates.io
-You'll need Rust 1.51.0 or newer.
+You'll need Rust 1.53.0 or newer.
 
 ```bash
 cargo install remodel

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,20 +82,18 @@ fn run(options: Options) -> Result<(), anyhow::Error> {
             let (contents, chunk_name) = load_script(&script)?;
             let lua = Lua::new();
 
-            {
-                let lua_args = args
-                    .into_iter()
-                    .map(|value| value.to_lua(&lua))
-                    .collect::<Result<Vec<_>, _>>()?;
+            let lua_args = args
+                .into_iter()
+                .map(|value| value.to_lua(&lua))
+                .collect::<Result<Vec<_>, _>>()?;
 
-                RemodelContext::new(auth_cookie).inject(&lua)?;
+            RemodelContext::new(auth_cookie).inject(&lua)?;
 
-                RemodelApi::inject(&lua)?;
-                RobloxApi::inject(&lua)?;
+            RemodelApi::inject(&lua)?;
+            RobloxApi::inject(&lua)?;
 
-                let chunk = lua.load(&contents).set_name(&chunk_name)?;
-                chunk.call(MultiValue::from_vec(lua_args))
-            }?;
+            let chunk = lua.load(&contents).set_name(&chunk_name)?;
+            chunk.call(MultiValue::from_vec(lua_args))?;
 
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use backtrace::Backtrace;
-use rlua::{Lua, MultiValue, ToLua};
+use mlua::{Lua, MultiValue, ToLua};
 use structopt::StructOpt;
 
 use crate::{
@@ -82,20 +82,20 @@ fn run(options: Options) -> Result<(), anyhow::Error> {
             let (contents, chunk_name) = load_script(&script)?;
             let lua = Lua::new();
 
-            lua.context(move |context| {
+            {
                 let lua_args = args
                     .into_iter()
-                    .map(|value| value.to_lua(context))
+                    .map(|value| value.to_lua(&lua))
                     .collect::<Result<Vec<_>, _>>()?;
 
-                RemodelContext::new(auth_cookie).inject(context)?;
+                RemodelContext::new(auth_cookie).inject(&lua)?;
 
-                RemodelApi::inject(context)?;
-                RobloxApi::inject(context)?;
+                RemodelApi::inject(&lua)?;
+                RobloxApi::inject(&lua)?;
 
-                let chunk = context.load(&contents).set_name(&chunk_name)?;
+                let chunk = lua.load(&contents).set_name(&chunk_name)?;
                 chunk.call(MultiValue::from_vec(lua_args))
-            })?;
+            }?;
 
             Ok(())
         }

--- a/src/remodel_api/json.rs
+++ b/src/remodel_api/json.rs
@@ -1,4 +1,4 @@
-use mlua::{Lua, FromLua, Table, ToLua, UserData, UserDataMethods, Value as LuaValue};
+use mlua::{FromLua, Lua, Table, ToLua, UserData, UserDataMethods, Value as LuaValue};
 use serde::Serialize;
 use serde_json::{
     ser::{PrettyFormatter, Serializer},

--- a/src/remodel_api/mod.rs
+++ b/src/remodel_api/mod.rs
@@ -1,7 +1,7 @@
 mod json;
 mod remodel;
 
-use rlua::Context;
+use mlua::Lua;
 
 pub use json::Json;
 pub use remodel::Remodel;
@@ -9,7 +9,7 @@ pub use remodel::Remodel;
 pub struct RemodelApi;
 
 impl RemodelApi {
-    pub fn inject(context: Context<'_>) -> rlua::Result<()> {
+    pub fn inject(context: &Lua) -> mlua::Result<()> {
         context.globals().set("remodel", Remodel)?;
         context.globals().set("json", Json)?;
 

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -51,10 +51,7 @@ impl Remodel {
         Remodel::import_tree_children(context, source_tree)
     }
 
-    fn read_binary_place_file<'lua>(
-        context: &'lua Lua,
-        path: &Path,
-    ) -> mlua::Result<LuaInstance> {
+    fn read_binary_place_file<'lua>(context: &'lua Lua, path: &Path) -> mlua::Result<LuaInstance> {
         let file = BufReader::new(File::open(path).map_err(mlua::Error::external)?);
         let source_tree = rbx_binary::from_reader(file).map_err(mlua::Error::external)?;
 
@@ -97,10 +94,7 @@ impl Remodel {
         Ok(instances)
     }
 
-    pub fn import_tree_root(
-        context: &Lua,
-        mut source_tree: WeakDom,
-    ) -> mlua::Result<LuaInstance> {
+    pub fn import_tree_root(context: &Lua, mut source_tree: WeakDom) -> mlua::Result<LuaInstance> {
         let master_tree = RemodelContext::get(context)?.master_tree;
         let mut master_handle = master_tree.lock().unwrap();
 

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -12,7 +12,7 @@ use reqwest::{
     header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
     StatusCode,
 };
-use rlua::{Context, UserData, UserDataMethods};
+use mlua::{Lua, UserData, UserDataMethods};
 
 use crate::{
     remodel_context::RemodelContext,
@@ -32,51 +32,51 @@ fn xml_decode_options() -> rbx_xml::DecodeOptions {
 pub struct Remodel;
 
 impl Remodel {
-    fn read_xml_place_file<'lua>(context: Context<'lua>, path: &Path) -> rlua::Result<LuaInstance> {
-        let file = BufReader::new(File::open(path).map_err(rlua::Error::external)?);
+    fn read_xml_place_file<'lua>(context: &'lua Lua, path: &Path) -> mlua::Result<LuaInstance> {
+        let file = BufReader::new(File::open(path).map_err(mlua::Error::external)?);
         let source_tree =
-            rbx_xml::from_reader(file, xml_decode_options()).map_err(rlua::Error::external)?;
+            rbx_xml::from_reader(file, xml_decode_options()).map_err(mlua::Error::external)?;
 
         Remodel::import_tree_root(context, source_tree)
     }
 
     fn read_xml_model_file<'lua>(
-        context: Context<'lua>,
+        context: &'lua Lua,
         path: &Path,
-    ) -> rlua::Result<Vec<LuaInstance>> {
-        let file = BufReader::new(File::open(path).map_err(rlua::Error::external)?);
+    ) -> mlua::Result<Vec<LuaInstance>> {
+        let file = BufReader::new(File::open(path).map_err(mlua::Error::external)?);
         let source_tree =
-            rbx_xml::from_reader(file, xml_decode_options()).map_err(rlua::Error::external)?;
+            rbx_xml::from_reader(file, xml_decode_options()).map_err(mlua::Error::external)?;
 
         Remodel::import_tree_children(context, source_tree)
     }
 
     fn read_binary_place_file<'lua>(
-        context: Context<'lua>,
+        context: &'lua Lua,
         path: &Path,
-    ) -> rlua::Result<LuaInstance> {
-        let file = BufReader::new(File::open(path).map_err(rlua::Error::external)?);
-        let source_tree = rbx_binary::from_reader(file).map_err(rlua::Error::external)?;
+    ) -> mlua::Result<LuaInstance> {
+        let file = BufReader::new(File::open(path).map_err(mlua::Error::external)?);
+        let source_tree = rbx_binary::from_reader(file).map_err(mlua::Error::external)?;
 
         Remodel::import_tree_root(context, source_tree)
     }
 
     fn read_binary_model_file<'lua>(
-        context: Context<'lua>,
+        context: &'lua Lua,
         path: &Path,
-    ) -> rlua::Result<Vec<LuaInstance>> {
-        let file = BufReader::new(File::open(path).map_err(rlua::Error::external)?);
+    ) -> mlua::Result<Vec<LuaInstance>> {
+        let file = BufReader::new(File::open(path).map_err(mlua::Error::external)?);
 
         let source_tree = rbx_binary::from_reader(file)
-            .map_err(|err| rlua::Error::external(format!("{:?}", err)))?;
+            .map_err(|err| mlua::Error::external(format!("{:?}", err)))?;
 
         Remodel::import_tree_children(context, source_tree)
     }
 
     pub fn import_tree_children(
-        context: Context<'_>,
+        context: &Lua,
         mut source_tree: WeakDom,
-    ) -> rlua::Result<Vec<LuaInstance>> {
+    ) -> mlua::Result<Vec<LuaInstance>> {
         let master_tree = RemodelContext::get(context)?.master_tree;
         let mut master_handle = master_tree.lock().unwrap();
 
@@ -98,9 +98,9 @@ impl Remodel {
     }
 
     pub fn import_tree_root(
-        context: Context<'_>,
+        context: &Lua,
         mut source_tree: WeakDom,
-    ) -> rlua::Result<LuaInstance> {
+    ) -> mlua::Result<LuaInstance> {
         let master_tree = RemodelContext::get(context)?.master_tree;
         let mut master_handle = master_tree.lock().unwrap();
 
@@ -117,82 +117,82 @@ impl Remodel {
         Ok(LuaInstance::new(Arc::clone(&master_tree), new_root_ref))
     }
 
-    fn write_xml_place_file(lua_instance: LuaInstance, path: &Path) -> rlua::Result<()> {
-        let file = BufWriter::new(File::create(&path).map_err(rlua::Error::external)?);
+    fn write_xml_place_file(lua_instance: LuaInstance, path: &Path) -> mlua::Result<()> {
+        let file = BufWriter::new(File::create(&path).map_err(mlua::Error::external)?);
 
         let tree = lua_instance.tree.lock().unwrap();
         let instance = tree
             .get_by_ref(lua_instance.id)
-            .ok_or_else(|| rlua::Error::external("Cannot save a destroyed instance."))?;
+            .ok_or_else(|| mlua::Error::external("Cannot save a destroyed instance."))?;
 
         if instance.class != "DataModel" {
-            return Err(rlua::Error::external(
+            return Err(mlua::Error::external(
                 "Only DataModel instances can be saved as place files.",
             ));
         }
 
         rbx_xml::to_writer(file, &tree, instance.children(), xml_encode_options())
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         Ok(())
     }
 
-    fn write_binary_place_file(lua_instance: LuaInstance, path: &Path) -> rlua::Result<()> {
-        let file = BufWriter::new(File::create(&path).map_err(rlua::Error::external)?);
+    fn write_binary_place_file(lua_instance: LuaInstance, path: &Path) -> mlua::Result<()> {
+        let file = BufWriter::new(File::create(&path).map_err(mlua::Error::external)?);
 
         let tree = lua_instance.tree.lock().unwrap();
         let instance = tree
             .get_by_ref(lua_instance.id)
-            .ok_or_else(|| rlua::Error::external("Cannot save a destroyed instance."))?;
+            .ok_or_else(|| mlua::Error::external("Cannot save a destroyed instance."))?;
 
         if instance.class != "DataModel" {
-            return Err(rlua::Error::external(
+            return Err(mlua::Error::external(
                 "Only DataModel instances can be saved as place files.",
             ));
         }
 
-        rbx_binary::to_writer(file, &tree, instance.children()).map_err(rlua::Error::external)?;
+        rbx_binary::to_writer(file, &tree, instance.children()).map_err(mlua::Error::external)?;
 
         Ok(())
     }
 
-    fn write_xml_model_file(lua_instance: LuaInstance, path: &Path) -> rlua::Result<()> {
-        let file = BufWriter::new(File::create(&path).map_err(rlua::Error::external)?);
+    fn write_xml_model_file(lua_instance: LuaInstance, path: &Path) -> mlua::Result<()> {
+        let file = BufWriter::new(File::create(&path).map_err(mlua::Error::external)?);
 
         let tree = lua_instance.tree.lock().unwrap();
         let instance = tree
             .get_by_ref(lua_instance.id)
-            .ok_or_else(|| rlua::Error::external("Cannot save a destroyed instance."))?;
+            .ok_or_else(|| mlua::Error::external("Cannot save a destroyed instance."))?;
 
         if instance.class == "DataModel" {
-            return Err(rlua::Error::external(
+            return Err(mlua::Error::external(
                 "DataModel instances must be saved as place files, not model files.",
             ));
         }
 
         rbx_xml::to_writer(file, &tree, &[lua_instance.id], xml_encode_options())
-            .map_err(rlua::Error::external)
+            .map_err(mlua::Error::external)
     }
 
-    fn write_binary_model_file(lua_instance: LuaInstance, path: &Path) -> rlua::Result<()> {
-        let file = BufWriter::new(File::create(&path).map_err(rlua::Error::external)?);
+    fn write_binary_model_file(lua_instance: LuaInstance, path: &Path) -> mlua::Result<()> {
+        let file = BufWriter::new(File::create(&path).map_err(mlua::Error::external)?);
 
         let tree = lua_instance.tree.lock().unwrap();
         let instance = tree
             .get_by_ref(lua_instance.id)
-            .ok_or_else(|| rlua::Error::external("Cannot save a destroyed instance."))?;
+            .ok_or_else(|| mlua::Error::external("Cannot save a destroyed instance."))?;
 
         if instance.class == "DataModel" {
-            return Err(rlua::Error::external(
+            return Err(mlua::Error::external(
                 "DataModel instances must be saved as place files, not model files.",
             ));
         }
 
         rbx_binary::to_writer(file, &tree, &[lua_instance.id])
-            .map_err(|err| rlua::Error::external(format!("{:?}", err)))
+            .map_err(|err| mlua::Error::external(format!("{:?}", err)))
     }
 
-    fn read_model_asset(context: Context<'_>, asset_id: u64) -> rlua::Result<Vec<LuaInstance>> {
+    fn read_model_asset(context: &Lua, asset_id: u64) -> mlua::Result<Vec<LuaInstance>> {
         let re_context = RemodelContext::get(context)?;
         let auth_cookie = re_context.auth_cookie();
         let url = format!("https://assetdelivery.roblox.com/v1/asset/?id={}", asset_id);
@@ -200,7 +200,7 @@ impl Remodel {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60 * 3))
             .build()
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         let mut request = client.get(&url);
 
@@ -210,20 +210,20 @@ impl Remodel {
             log::warn!("No auth cookie detected, Remodel may be unable to download this asset.");
         }
 
-        let mut response = request.send().map_err(rlua::Error::external)?;
+        let mut response = request.send().map_err(mlua::Error::external)?;
 
         let mut body = Vec::new();
         response
             .read_to_end(&mut body)
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         let source_tree = match sniff_type(&body) {
             Some(DocumentType::Binary) => {
-                rbx_binary::from_reader(body.as_slice()).map_err(rlua::Error::external)?
+                rbx_binary::from_reader(body.as_slice()).map_err(mlua::Error::external)?
             }
 
             Some(DocumentType::Xml) => rbx_xml::from_reader(body.as_slice(), xml_decode_options())
-                .map_err(rlua::Error::external)?,
+                .map_err(mlua::Error::external)?,
 
             None => {
                 let first_few_bytes: Vec<_> = body.iter().copied().take(20).collect();
@@ -234,14 +234,14 @@ impl Remodel {
                     asset_id, snippet
                 );
 
-                return Err(rlua::Error::external(message));
+                return Err(mlua::Error::external(message));
             }
         };
 
         Remodel::import_tree_children(context, source_tree)
     }
 
-    fn read_place_asset(context: Context<'_>, asset_id: u64) -> rlua::Result<LuaInstance> {
+    fn read_place_asset(context: &Lua, asset_id: u64) -> mlua::Result<LuaInstance> {
         let re_context = RemodelContext::get(context)?;
         let auth_cookie = re_context.auth_cookie();
         let url = format!("https://assetdelivery.roblox.com/v1/asset/?id={}", asset_id);
@@ -249,7 +249,7 @@ impl Remodel {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60 * 3))
             .build()
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
         let mut request = client.get(&url);
 
         if let Some(auth_cookie) = auth_cookie {
@@ -258,20 +258,20 @@ impl Remodel {
             log::warn!("No auth cookie detected, Remodel may be unable to download this asset.");
         }
 
-        let mut response = request.send().map_err(rlua::Error::external)?;
+        let mut response = request.send().map_err(mlua::Error::external)?;
 
         let mut body = Vec::new();
         response
             .read_to_end(&mut body)
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         let source_tree = match sniff_type(&body) {
             Some(DocumentType::Binary) => {
-                rbx_binary::from_reader(body.as_slice()).map_err(rlua::Error::external)?
+                rbx_binary::from_reader(body.as_slice()).map_err(mlua::Error::external)?
             }
 
             Some(DocumentType::Xml) => rbx_xml::from_reader(body.as_slice(), xml_decode_options())
-                .map_err(rlua::Error::external)?,
+                .map_err(mlua::Error::external)?,
 
             None => {
                 let first_few_bytes: Vec<_> = body.iter().copied().take(20).collect();
@@ -282,7 +282,7 @@ impl Remodel {
                     asset_id, snippet
                 );
 
-                return Err(rlua::Error::external(message));
+                return Err(mlua::Error::external(message));
             }
         };
 
@@ -290,55 +290,55 @@ impl Remodel {
     }
 
     fn write_existing_model_asset(
-        context: Context<'_>,
+        context: &Lua,
         lua_instance: LuaInstance,
         asset_id: u64,
-    ) -> rlua::Result<()> {
+    ) -> mlua::Result<()> {
         let tree = lua_instance.tree.lock().unwrap();
         let instance = tree
             .get_by_ref(lua_instance.id)
-            .ok_or_else(|| rlua::Error::external("Cannot save a destroyed instance."))?;
+            .ok_or_else(|| mlua::Error::external("Cannot save a destroyed instance."))?;
 
         if instance.class == "DataModel" {
-            return Err(rlua::Error::external(
+            return Err(mlua::Error::external(
                 "DataModel instances must be saved as place files, not model files.",
             ));
         }
 
         let mut buffer = Vec::new();
         rbx_binary::to_writer(&mut buffer, &tree, &[lua_instance.id])
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         Remodel::upload_asset(context, buffer, asset_id)
     }
 
     fn write_existing_place_asset(
-        context: Context<'_>,
+        context: &Lua,
         lua_instance: LuaInstance,
         asset_id: u64,
-    ) -> rlua::Result<()> {
+    ) -> mlua::Result<()> {
         let tree = lua_instance.tree.lock().unwrap();
         let instance = tree
             .get_by_ref(lua_instance.id)
-            .ok_or_else(|| rlua::Error::external("Cannot save a destroyed instance."))?;
+            .ok_or_else(|| mlua::Error::external("Cannot save a destroyed instance."))?;
 
         if instance.class != "DataModel" {
-            return Err(rlua::Error::external(
+            return Err(mlua::Error::external(
                 "Only DataModel instances can be saved as place files.",
             ));
         }
 
         let mut buffer = Vec::new();
         rbx_binary::to_writer(&mut buffer, &tree, instance.children())
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         Remodel::upload_asset(context, buffer, asset_id)
     }
 
-    fn upload_asset(context: Context<'_>, buffer: Vec<u8>, asset_id: u64) -> rlua::Result<()> {
+    fn upload_asset(context: &Lua, buffer: Vec<u8>, asset_id: u64) -> mlua::Result<()> {
         let re_context = RemodelContext::get(context)?;
         let auth_cookie = re_context.auth_cookie().ok_or_else(|| {
-            rlua::Error::external(
+            mlua::Error::external(
                 "Uploading assets requires an auth cookie, please log into Roblox Studio.",
             )
         })?;
@@ -351,7 +351,7 @@ impl Remodel {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60 * 3))
             .build()
-            .map_err(rlua::Error::external)?;
+            .map_err(mlua::Error::external)?;
 
         let build_request = move || {
             client
@@ -364,7 +364,7 @@ impl Remodel {
         };
 
         log::debug!("Uploading to Roblox...");
-        let mut response = build_request().send().map_err(rlua::Error::external)?;
+        let mut response = build_request().send().map_err(mlua::Error::external)?;
 
         // Starting in Feburary, 2021, the upload endpoint performs CSRF challenges.
         // If we receive an HTTP 403 with a X-CSRF-Token reply, we should retry the
@@ -375,14 +375,14 @@ impl Remodel {
                 response = build_request()
                     .header("X-CSRF-Token", csrf_token)
                     .send()
-                    .map_err(rlua::Error::external)?;
+                    .map_err(mlua::Error::external)?;
             }
         }
 
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(rlua::Error::external(format!(
+            Err(mlua::Error::external(format!(
                 "Roblox API returned an error, status {}.",
                 response.status()
             )))
@@ -390,19 +390,19 @@ impl Remodel {
     }
 
     fn get_raw_property<'a>(
-        context: Context<'a>,
+        context: &'a Lua,
         lua_instance: LuaInstance,
         name: &str,
-    ) -> rlua::Result<rlua::Value<'a>> {
+    ) -> mlua::Result<mlua::Value<'a>> {
         let tree = lua_instance.tree.lock().unwrap();
 
         let instance = tree.get_by_ref(lua_instance.id).ok_or_else(|| {
-            rlua::Error::external("Cannot call remodel.getRawProperty on a destroyed instance.")
+            mlua::Error::external("Cannot call remodel.getRawProperty on a destroyed instance.")
         })?;
 
         match instance.properties.get(name) {
             Some(value) => rbxvalue_to_lua(context, value),
-            None => Ok(rlua::Value::Nil),
+            None => Ok(mlua::Value::Nil),
         }
     }
 
@@ -410,12 +410,12 @@ impl Remodel {
         lua_instance: LuaInstance,
         key: String,
         ty: VariantType,
-        lua_value: rlua::Value<'_>,
-    ) -> rlua::Result<()> {
+        lua_value: mlua::Value<'_>,
+    ) -> mlua::Result<()> {
         let mut tree = lua_instance.tree.lock().unwrap();
 
         let instance = tree.get_by_ref_mut(lua_instance.id).ok_or_else(|| {
-            rlua::Error::external("Cannot call remodel.setRawProperty on a destroyed instance.")
+            mlua::Error::external("Cannot call remodel.setRawProperty on a destroyed instance.")
         })?;
 
         let value = lua_to_rbxvalue(ty, lua_value)?;
@@ -436,9 +436,9 @@ impl UserData for Remodel {
 
         methods.add_function(
             "setRawProperty",
-            |_context, (instance, name, lua_ty, value): (LuaInstance, String, String, rlua::Value<'_>)| {
+            |_context, (instance, name, lua_ty, value): (LuaInstance, String, String, mlua::Value<'_>)| {
                 let ty = type_from_str(&lua_ty)
-                    .ok_or_else(|| rlua::Error::external(format!("{} is not a valid Roblox type.", lua_ty)))?;
+                    .ok_or_else(|| mlua::Error::external(format!("{} is not a valid Roblox type.", lua_ty)))?;
 
                 Self::set_raw_property(instance, name, ty, value)
             },
@@ -450,7 +450,7 @@ impl UserData for Remodel {
             match path.extension().and_then(OsStr::to_str) {
                 Some("rbxlx") => Remodel::read_xml_place_file(context, path),
                 Some("rbxl") => Remodel::read_binary_place_file(context, path),
-                _ => Err(rlua::Error::external(format!(
+                _ => Err(mlua::Error::external(format!(
                     "Invalid place file path {}",
                     path.display()
                 ))),
@@ -463,7 +463,7 @@ impl UserData for Remodel {
             match path.extension().and_then(OsStr::to_str) {
                 Some("rbxmx") => Remodel::read_xml_model_file(context, path),
                 Some("rbxm") => Remodel::read_binary_model_file(context, path),
-                _ => Err(rlua::Error::external(format!(
+                _ => Err(mlua::Error::external(format!(
                     "Invalid model file path {}",
                     path.display()
                 ))),
@@ -471,13 +471,13 @@ impl UserData for Remodel {
         });
 
         methods.add_function("readModelAsset", |context, asset_id: String| {
-            let asset_id = asset_id.parse().map_err(rlua::Error::external)?;
+            let asset_id = asset_id.parse().map_err(mlua::Error::external)?;
 
             Remodel::read_model_asset(context, asset_id)
         });
 
         methods.add_function("readPlaceAsset", |context, asset_id: String| {
-            let asset_id = asset_id.parse().map_err(rlua::Error::external)?;
+            let asset_id = asset_id.parse().map_err(mlua::Error::external)?;
 
             Remodel::read_place_asset(context, asset_id)
         });
@@ -485,7 +485,7 @@ impl UserData for Remodel {
         methods.add_function(
             "writeExistingModelAsset",
             |context, (instance, asset_id): (LuaInstance, String)| {
-                let asset_id = asset_id.parse().map_err(rlua::Error::external)?;
+                let asset_id = asset_id.parse().map_err(mlua::Error::external)?;
 
                 Remodel::write_existing_model_asset(context, instance, asset_id)
             },
@@ -494,7 +494,7 @@ impl UserData for Remodel {
         methods.add_function(
             "writeExistingPlaceAsset",
             |context, (instance, asset_id): (LuaInstance, String)| {
-                let asset_id = asset_id.parse().map_err(rlua::Error::external)?;
+                let asset_id = asset_id.parse().map_err(mlua::Error::external)?;
 
                 Remodel::write_existing_place_asset(context, instance, asset_id)
             },
@@ -508,7 +508,7 @@ impl UserData for Remodel {
                 match path.extension().and_then(OsStr::to_str) {
                     Some("rbxlx") => Remodel::write_xml_place_file(instance, path),
                     Some("rbxl") => Remodel::write_binary_place_file(instance, path),
-                    _ => Err(rlua::Error::external(format!(
+                    _ => Err(mlua::Error::external(format!(
                         "Invalid place file path {}",
                         path.display()
                     ))),
@@ -524,7 +524,7 @@ impl UserData for Remodel {
                 match path.extension().and_then(OsStr::to_str) {
                     Some("rbxmx") => Remodel::write_xml_model_file(instance, path),
                     Some("rbxm") => Remodel::write_binary_model_file(instance, path),
-                    _ => Err(rlua::Error::external(format!(
+                    _ => Err(mlua::Error::external(format!(
                         "Invalid model file path {}",
                         path.display()
                     ))),
@@ -533,16 +533,16 @@ impl UserData for Remodel {
         );
 
         methods.add_function("readFile", |_context, path: String| {
-            fs::read_to_string(path).map_err(rlua::Error::external)
+            fs::read_to_string(path).map_err(mlua::Error::external)
         });
 
         methods.add_function("readDir", |_context, path: String| {
             fs::read_dir(path)
-                .map_err(rlua::Error::external)?
+                .map_err(mlua::Error::external)?
                 .filter_map(|entry| {
                     let entry = match entry {
                         Ok(entry) => entry,
-                        Err(err) => return Some(Err(rlua::Error::external(err))),
+                        Err(err) => return Some(Err(mlua::Error::external(err))),
                     };
 
                     match entry.file_name().into_string() {
@@ -561,22 +561,22 @@ impl UserData for Remodel {
 
         methods.add_function(
             "writeFile",
-            |_context, (path, contents): (String, rlua::String)| {
-                fs::write(path, contents.as_bytes()).map_err(rlua::Error::external)
+            |_context, (path, contents): (String, mlua::String)| {
+                fs::write(path, contents.as_bytes()).map_err(mlua::Error::external)
             },
         );
 
         methods.add_function("createDirAll", |_context, path: String| {
-            fs::create_dir_all(path).map_err(rlua::Error::external)
+            fs::create_dir_all(path).map_err(mlua::Error::external)
         });
 
         methods.add_function("isFile", |_context, path: String| {
-            let meta = fs::metadata(path).map_err(rlua::Error::external)?;
+            let meta = fs::metadata(path).map_err(mlua::Error::external)?;
             Ok(meta.is_file())
         });
 
         methods.add_function("isDir", |_context, path: String| {
-            let meta = fs::metadata(path).map_err(rlua::Error::external)?;
+            let meta = fs::metadata(path).map_err(mlua::Error::external)?;
             Ok(meta.is_dir())
         });
     }

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -7,12 +7,12 @@ use std::{
     time::Duration,
 };
 
+use mlua::{Lua, UserData, UserDataMethods};
 use rbx_dom_weak::{types::VariantType, InstanceBuilder, WeakDom};
 use reqwest::{
     header::{ACCEPT, CONTENT_TYPE, COOKIE, USER_AGENT},
     StatusCode,
 };
-use mlua::{Lua, UserData, UserDataMethods};
 
 use crate::{
     remodel_context::RemodelContext,

--- a/src/remodel_context.rs
+++ b/src/remodel_context.rs
@@ -3,8 +3,8 @@
 
 use std::sync::{Arc, Mutex};
 
-use rbx_dom_weak::{InstanceBuilder, WeakDom};
 use mlua::{Lua, UserData};
+use rbx_dom_weak::{InstanceBuilder, WeakDom};
 
 #[derive(Clone)]
 pub struct RemodelContext {

--- a/src/remodel_context.rs
+++ b/src/remodel_context.rs
@@ -4,7 +4,7 @@
 use std::sync::{Arc, Mutex};
 
 use rbx_dom_weak::{InstanceBuilder, WeakDom};
-use rlua::{Context, UserData};
+use mlua::{Lua, UserData};
 
 #[derive(Clone)]
 pub struct RemodelContext {
@@ -24,11 +24,11 @@ impl RemodelContext {
         }
     }
 
-    pub fn get(context: Context<'_>) -> rlua::Result<Self> {
+    pub fn get(context: &Lua) -> mlua::Result<Self> {
         context.named_registry_value("remodel_context")
     }
 
-    pub fn inject(self, context: Context<'_>) -> rlua::Result<()> {
+    pub fn inject(self, context: &Lua) -> mlua::Result<()> {
         context.set_named_registry_value("remodel_context", self)?;
 
         Ok(())

--- a/src/roblox_api/cframe.rs
+++ b/src/roblox_api/cframe.rs
@@ -1,5 +1,5 @@
 use rbx_dom_weak::types::{CFrame, Matrix3, Vector3};
-use rlua::{UserData, UserDataMethods, Value as LuaValue};
+use mlua::{UserData, UserDataMethods, Value as LuaValue};
 
 use crate::value::{CFrameValue, Vector3Value};
 
@@ -62,7 +62,7 @@ impl UserData for CFrameUserData {
 
                 match (x, y, z) {
                     (Some(x), Some(y), Some(z)) => Ok(Self::from_position(x, y, z)),
-                    _ => Err(rlua::Error::external(
+                    _ => Err(mlua::Error::external(
                         "invalid argument #1 to 'new' (Vector3 expected)",
                     )),
                 }

--- a/src/roblox_api/cframe.rs
+++ b/src/roblox_api/cframe.rs
@@ -1,5 +1,5 @@
-use rbx_dom_weak::types::{CFrame, Matrix3, Vector3};
 use mlua::{UserData, UserDataMethods, Value as LuaValue};
+use rbx_dom_weak::types::{CFrame, Matrix3, Vector3};
 
 use crate::value::{CFrameValue, Vector3Value};
 

--- a/src/roblox_api/instance.rs
+++ b/src/roblox_api/instance.rs
@@ -4,9 +4,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use mlua::{FromLua, Lua, MetaMethod, ToLua, UserData, UserDataMethods};
 use rbx_dom_weak::{types::Ref, InstanceBuilder, WeakDom};
 use rbx_reflection::ClassTag;
-use mlua::{Lua, FromLua, MetaMethod, ToLua, UserData, UserDataMethods};
 
 #[derive(Clone)]
 pub struct LuaInstance {

--- a/src/roblox_api/instance.rs
+++ b/src/roblox_api/instance.rs
@@ -235,10 +235,7 @@ impl LuaInstance {
         }
     }
 
-    fn get_class_name<'lua>(
-        &self,
-        context: &'lua Lua,
-    ) -> mlua::Result<mlua::Value<'lua>> {
+    fn get_class_name<'lua>(&self, context: &'lua Lua) -> mlua::Result<mlua::Value<'lua>> {
         let tree = self.tree.lock().unwrap();
 
         let instance = tree.get_by_ref(self.id).ok_or_else(|| {
@@ -294,11 +291,7 @@ impl LuaInstance {
         }
     }
 
-    fn set_parent<'lua>(
-        &self,
-        context: &'lua Lua,
-        value: mlua::Value<'lua>,
-    ) -> mlua::Result<()> {
+    fn set_parent<'lua>(&self, context: &'lua Lua, value: mlua::Value<'lua>) -> mlua::Result<()> {
         let mut tree = self.tree.lock().unwrap();
 
         match Option::<LuaInstance>::from_lua(value, context)? {
@@ -333,11 +326,7 @@ impl LuaInstance {
         instance.name.as_str().to_lua(context)
     }
 
-    fn meta_index<'lua>(
-        &self,
-        context: &'lua Lua,
-        key: &str,
-    ) -> mlua::Result<mlua::Value<'lua>> {
+    fn meta_index<'lua>(&self, context: &'lua Lua, key: &str) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "Name" => self.get_name(context),
             "ClassName" => self.get_class_name(context),

--- a/src/roblox_api/mod.rs
+++ b/src/roblox_api/mod.rs
@@ -4,7 +4,7 @@ mod instance;
 use std::sync::Arc;
 
 use rbx_dom_weak::InstanceBuilder;
-use rlua::{Context, UserData, UserDataMethods};
+use mlua::{Lua, UserData, UserDataMethods};
 
 use crate::{
     remodel_context::RemodelContext,
@@ -17,7 +17,7 @@ pub use instance::LuaInstance;
 pub struct RobloxApi;
 
 impl RobloxApi {
-    pub fn inject(context: Context<'_>) -> rlua::Result<()> {
+    pub fn inject(context: &Lua) -> mlua::Result<()> {
         context.globals().set("Instance", Instance)?;
         context.globals().set("Vector3", Vector3)?;
         context.globals().set("Vector3int16", Vector3int16)?;
@@ -36,7 +36,7 @@ impl UserData for Instance {
             let database = rbx_reflection_database::get();
 
             if !database.classes.contains_key(class_name.as_str()) {
-                return Err(rlua::Error::external(format!(
+                return Err(mlua::Error::external(format!(
                     "'{}' is not a valid class of Instance.",
                     class_name,
                 )));

--- a/src/roblox_api/mod.rs
+++ b/src/roblox_api/mod.rs
@@ -3,8 +3,8 @@ mod instance;
 
 use std::sync::Arc;
 
-use rbx_dom_weak::InstanceBuilder;
 use mlua::{Lua, UserData, UserDataMethods};
+use rbx_dom_weak::InstanceBuilder;
 
 use crate::{
     remodel_context::RemodelContext,

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,10 +1,10 @@
 //! Defines how to turn Variant values into Lua values and back.
 
-use rbx_dom_weak::types::{
-    CFrame, Color3, Color3uint8, Variant, VariantType, Vector3, Vector3int16,
-};
 use mlua::{
     Lua, MetaMethod, Result as LuaResult, ToLua, UserData, UserDataMethods, Value as LuaValue,
+};
+use rbx_dom_weak::types::{
+    CFrame, Color3, Color3uint8, Variant, VariantType, Vector3, Vector3int16,
 };
 use std::fmt;
 use std::ops;

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,15 +3,15 @@
 use rbx_dom_weak::types::{
     CFrame, Color3, Color3uint8, Variant, VariantType, Vector3, Vector3int16,
 };
-use rlua::{
-    Context, MetaMethod, Result as LuaResult, ToLua, UserData, UserDataMethods, Value as LuaValue,
+use mlua::{
+    Lua, MetaMethod, Result as LuaResult, ToLua, UserData, UserDataMethods, Value as LuaValue,
 };
 use std::fmt;
 use std::ops;
 
-pub fn rbxvalue_to_lua<'lua>(context: Context<'lua>, value: &Variant) -> LuaResult<LuaValue<'lua>> {
+pub fn rbxvalue_to_lua<'lua>(context: &'lua Lua, value: &Variant) -> LuaResult<LuaValue<'lua>> {
     fn unimplemented_type(name: &str) -> LuaResult<LuaValue<'_>> {
-        Err(rlua::Error::external(format!(
+        Err(mlua::Error::external(format!(
             "Values of type {} are not yet implemented.",
             name
         )))
@@ -48,7 +48,7 @@ pub fn rbxvalue_to_lua<'lua>(context: Context<'lua>, value: &Variant) -> LuaResu
         Variant::Vector3(_) => unimplemented_type("Vector3"),
         Variant::Vector3int16(value) => Vector3int16Value::new(*value).to_lua(context),
 
-        _ => Err(rlua::Error::external(format!(
+        _ => Err(mlua::Error::external(format!(
             "The type '{:?}' is unknown to Remodel, please file a bug!",
             value.ty()
         ))),
@@ -98,11 +98,11 @@ pub fn lua_to_rbxvalue(ty: VariantType, value: LuaValue<'_>) -> LuaResult<Varian
 
         (VariantType::BinaryString, LuaValue::String(lua_string)) => Ok(Variant::BinaryString(
             base64::decode(lua_string)
-                .map_err(rlua::Error::external)?
+                .map_err(mlua::Error::external)?
                 .into(),
         )),
 
-        (_, unknown_value) => Err(rlua::Error::external(format!(
+        (_, unknown_value) => Err(mlua::Error::external(format!(
             "The Lua value {:?} could not be converted to the Roblox type {:?}",
             unknown_value, ty
         ))),
@@ -160,14 +160,14 @@ impl Color3Value {
 
     fn meta_index<'lua>(
         &self,
-        context: Context<'lua>,
+        context: &'lua Lua,
         key: &str,
-    ) -> rlua::Result<rlua::Value<'lua>> {
+    ) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "r" | "R" => self.0.r.to_lua(context),
             "g" | "G" => self.0.g.to_lua(context),
             "b" | "B" => self.0.b.to_lua(context),
-            _ => Err(rlua::Error::external(format!(
+            _ => Err(mlua::Error::external(format!(
                 "'{}' is not a valid member of Color3",
                 key
             ))),
@@ -242,14 +242,14 @@ impl Vector3Value {
 
     fn meta_index<'lua>(
         &self,
-        context: Context<'lua>,
+        context: &'lua Lua,
         key: &str,
-    ) -> rlua::Result<rlua::Value<'lua>> {
+    ) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "X" => self.0.x.to_lua(context),
             "Y" => self.0.y.to_lua(context),
             "Z" => self.0.z.to_lua(context),
-            _ => Err(rlua::Error::external(format!(
+            _ => Err(mlua::Error::external(format!(
                 "'{}' is not a valid member of Vector3",
                 key
             ))),
@@ -322,14 +322,14 @@ impl Vector3int16Value {
 
     fn meta_index<'lua>(
         &self,
-        context: Context<'lua>,
+        context: &'lua Lua,
         key: &str,
-    ) -> rlua::Result<rlua::Value<'lua>> {
+    ) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "X" => self.0.x.to_lua(context),
             "Y" => self.0.y.to_lua(context),
             "Z" => self.0.z.to_lua(context),
-            _ => Err(rlua::Error::external(format!(
+            _ => Err(mlua::Error::external(format!(
                 "'{}' is not a valid member of Vector3",
                 key
             ))),
@@ -396,9 +396,9 @@ impl CFrameValue {
 
     fn meta_index<'lua>(
         &self,
-        context: Context<'lua>,
+        context: &'lua Lua,
         key: &str,
-    ) -> rlua::Result<rlua::Value<'lua>> {
+    ) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "X" => self.0.position.x.to_lua(context),
             "Y" => self.0.position.y.to_lua(context),
@@ -424,7 +424,7 @@ impl CFrameValue {
             "XVector" => Vector3Value::new(self.0.orientation.x).to_lua(context),
             "YVector" => Vector3Value::new(self.0.orientation.y).to_lua(context),
             "ZVector" => Vector3Value::new(self.0.orientation.z).to_lua(context),
-            _ => Err(rlua::Error::external(format!(
+            _ => Err(mlua::Error::external(format!(
                 "'{}' is not a valid member of CFrame",
                 key
             ))),

--- a/src/value.rs
+++ b/src/value.rs
@@ -158,11 +158,7 @@ impl Color3Value {
         Self(value)
     }
 
-    fn meta_index<'lua>(
-        &self,
-        context: &'lua Lua,
-        key: &str,
-    ) -> mlua::Result<mlua::Value<'lua>> {
+    fn meta_index<'lua>(&self, context: &'lua Lua, key: &str) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "r" | "R" => self.0.r.to_lua(context),
             "g" | "G" => self.0.g.to_lua(context),
@@ -240,11 +236,7 @@ impl Vector3Value {
         self.0
     }
 
-    fn meta_index<'lua>(
-        &self,
-        context: &'lua Lua,
-        key: &str,
-    ) -> mlua::Result<mlua::Value<'lua>> {
+    fn meta_index<'lua>(&self, context: &'lua Lua, key: &str) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "X" => self.0.x.to_lua(context),
             "Y" => self.0.y.to_lua(context),
@@ -320,11 +312,7 @@ impl Vector3int16Value {
         Self(value)
     }
 
-    fn meta_index<'lua>(
-        &self,
-        context: &'lua Lua,
-        key: &str,
-    ) -> mlua::Result<mlua::Value<'lua>> {
+    fn meta_index<'lua>(&self, context: &'lua Lua, key: &str) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "X" => self.0.x.to_lua(context),
             "Y" => self.0.y.to_lua(context),
@@ -394,11 +382,7 @@ impl CFrameValue {
         Self(value)
     }
 
-    fn meta_index<'lua>(
-        &self,
-        context: &'lua Lua,
-        key: &str,
-    ) -> mlua::Result<mlua::Value<'lua>> {
+    fn meta_index<'lua>(&self, context: &'lua Lua, key: &str) -> mlua::Result<mlua::Value<'lua>> {
         match key {
             "X" => self.0.position.x.to_lua(context),
             "Y" => self.0.position.y.to_lua(context),


### PR DESCRIPTION
The mlua package is more widely used and more actively maintained.

The next version of mlua also adds support for luau, which we could
consider switching to.