### PR TITLE
made read_place_asset error more clear

### DIFF
--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -268,11 +268,10 @@ impl Remodel {
                 .map_err(mlua::Error::external)?,
 
             None => {
-                let first_few_bytes: Vec<_> = body.iter().copied().take(20).collect();
-                let snippet = std::str::from_utf8(first_few_bytes.as_slice());
+                let snippet = std::str::from_utf8(body.as_slice());
 
                 let message = format!(
-                    "Unknown response trying to read model asset ID {}. First few bytes:\n{:?}",
+                    "Unknown response trying to read model asset ID {}. Response is:\n{:?}",
                     asset_id, snippet
                 );
 


### PR DESCRIPTION
Currently read_place_asset if the api returns an error will only give you the roblox code.
But for example code 0 has multiple error messages connected with it.
Example:
` {
  "errors": [
    {
      "code": 0,
      "message": "User is not authorized to access Asset."
    }
  ]
}`
and
`{
  "errors": [
    {
      "code": 0,
      "message": "Request asset was not found"
    }
  ]
}`
so In this pool request I decided to give full response form the endpoint and not only the code.