### PR TITLE
Add detailed error for swapping two arguments

### DIFF
--- a/src/remodel_api/mod.rs
+++ b/src/remodel_api/mod.rs
@@ -1,10 +1,12 @@
 mod json;
 mod remodel;
 
-use mlua::Lua;
+use mlua::{FromLuaMulti, Lua, Value as LuaValue};
 
 pub use json::Json;
 pub use remodel::Remodel;
+
+use crate::roblox_api::LuaInstance;
 
 pub struct RemodelApi;
 
@@ -14,5 +16,56 @@ impl RemodelApi {
         context.globals().set("json", Json)?;
 
         Ok(())
+    }
+}
+
+/// Takes (String, LuaInstance) as a variadic, but reports a useful error
+/// if the arguments are swapped.
+pub struct StringLuaInstanceBackCompat(pub (String, LuaInstance));
+
+impl<'lua> FromLuaMulti<'lua> for StringLuaInstanceBackCompat {
+    fn from_lua_multi(values: mlua::MultiValue<'lua>, _lua: &'lua Lua) -> mlua::Result<Self> {
+        let values = values.into_vec();
+
+        match (values.get(0), values.get(1)) {
+            (Some(LuaValue::String(filename)), Some(LuaValue::UserData(user_data))) => {
+                let instance = user_data.take::<LuaInstance>()?;
+
+                Ok(StringLuaInstanceBackCompat((
+                    filename.to_str()?.to_owned(),
+                    instance,
+                )))
+            }
+
+            (Some(user_data_value @ LuaValue::UserData(user_data)), Some(LuaValue::String(_))) => {
+                if user_data.is::<LuaInstance>() {
+                    Err(mlua::Error::external("The two arguments are swapped. The first argument should be the filename, and the second argument should be the instance."))
+                } else {
+                    Err(mlua::Error::external(format!(
+                        "Expected two arguments, a filename and an Instance. received string and {}.",
+                        user_data_value.type_name()
+                    )))
+                }
+            }
+
+            (Some(one), Some(two)) => Err(mlua::Error::external(format!(
+                "Expected two arguments, a filename and an Instance. received {} and {}.",
+                one.type_name(),
+                two.type_name()
+            ))),
+
+            (Some(one), None) => Err(mlua::Error::external(format!(
+                "Expected two arguments, a filename and an Instance. only received {}.",
+                one.type_name()
+            ))),
+
+            (None, Some(_)) => {
+                unreachable!("the first value of the MultiValue was None, but the second was Some")
+            }
+
+            (None, None) => Err(mlua::Error::external(
+                "Expected two arguments, a filename and an Instance.",
+            )),
+        }
     }
 }

--- a/src/remodel_api/remodel.rs
+++ b/src/remodel_api/remodel.rs
@@ -21,6 +21,8 @@ use crate::{
     value::{lua_to_rbxvalue, rbxvalue_to_lua, type_from_str},
 };
 
+use super::StringLuaInstanceBackCompat;
+
 fn xml_encode_options() -> rbx_xml::EncodeOptions {
     rbx_xml::EncodeOptions::new().property_behavior(rbx_xml::EncodePropertyBehavior::WriteUnknown)
 }
@@ -495,7 +497,7 @@ impl UserData for Remodel {
 
         methods.add_function(
             "writePlaceFile",
-            |_context, (lua_path, instance): (String, LuaInstance)| {
+            |_context, StringLuaInstanceBackCompat((lua_path, instance)): StringLuaInstanceBackCompat| {
                 let path = Path::new(&lua_path);
 
                 match path.extension().and_then(OsStr::to_str) {
@@ -511,7 +513,7 @@ impl UserData for Remodel {
 
         methods.add_function(
             "writeModelFile",
-            |_context, (lua_path, instance): (String, LuaInstance)| {
+            |_context, StringLuaInstanceBackCompat((lua_path, instance)): StringLuaInstanceBackCompat| {
                 let path = Path::new(&lua_path);
 
                 match path.extension().and_then(OsStr::to_str) {

--- a/test-scripts/write-place-model-old-order.lua
+++ b/test-scripts/write-place-model-old-order.lua
@@ -1,0 +1,15 @@
+local game = remodel.readPlaceFile("test-models/place-with-models.rbxlx")
+
+local success, problem = pcall(function()
+	remodel.writePlaceFile(game, "temp/new-place.rbxlx")
+end)
+
+assert(not success)
+assert(tostring(problem):match("The two arguments are swapped") ~= nil)
+
+success, problem = pcall(function()
+	remodel.writeModelFile(game, "temp/new-model.rbxmx")
+end)
+
+assert(not success)
+assert(tostring(problem):match("The two arguments are swapped") ~= nil)


### PR DESCRIPTION
This supports the recent breaking change to swap filename and path by giving a clear error on how to fix it.