### PR TITLE
doc: Update README installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Remodel can be installed with Foreman, a toolchain manager for Roblox projects:
 
 ```toml
 [tools]
-remodel = { source = "rojo-rbx/remodel", version = "0.10.0" }
+remodel = { source = "rojo-rbx/remodel", version = "0.11.0" }
 ```
 
 ### From GitHub Releases


### PR DESCRIPTION
Update README installation steps to match latest released version 0.11.0.

I recently installed remodel and then got confused when `writePlaceFile` wasn't working, which was due to me installing 0.10.0 but following the doc examples for 0.11.0.