### PR TITLE
Fixed documentation on WritePlaceFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Throws on error.
 
 ### `remodel.writePlaceFile`
 ```
-remodel.writePlaceFile(path: string, instance: DataModel)
+remodel.writePlaceFile(instance: DataModel, path: string)
 ```
 
 Saves an `rbxlx` file out of the given `DataModel` instance.


### PR DESCRIPTION
Documentation of WritePlaceFile was written down wrongly.
Swapping the variables around makes the documentation accurate to the code.